### PR TITLE
fix: 빈 그룹 생성 기본 코드, 파일명 수정하여 삭제

### DIFF
--- a/src/api/controllers/group.controller.js
+++ b/src/api/controllers/group.controller.js
@@ -6,17 +6,17 @@ module.exports = class GroupController {
     this.groupService = new GroupService();
   }
 
-  // 클라이언트 그룹 생성
+  //빈 Group 생성 //groupId 반환
   createGroup = async (req, res, next) => {
-    //const {userId} = res.locals.users;
-    const { clientId, groupName, gruopDescription } = req.body;
+    logger.info(`GroupController.createGroup Request`);
+    // const { userId } = res.locals.users;
+    const { groupName, groupDescription } = req.body;
 
     try {
       await this.groupService.createGroup({
-        //userId
-        clientId,
+        // userId,
         groupName,
-        gruopDescription,
+        groupDescription,
       });
       res.status(201).json({ message: '그룹 생성이 완료되었습니다.' });
     } catch (error) {

--- a/src/api/repositories/group.repository.js
+++ b/src/api/repositories/group.repository.js
@@ -1,22 +1,21 @@
 const { logger } = require('../../middlewares/logger');
-const { Groups, Clients } = require('../../db/models');
+const { Groups } = require('../../db/models');
 
 module.exports = class GroupRepository {
   constructor() {}
-  // 클라이언트 그룹 생성
+  //빈 Group 생성
   createGroup = async ({
     //userId,
-    clientId,
     groupName,
     groupDescription,
   }) => {
-    const findClientId = await Clients.findOne({ clientId });
-    const createData = await Groups.create({
-      //userId,
+    const createGroup = await Groups.create({
+      // userId,
       groupName,
       groupDescription,
     });
-    return findClientId, createData;
+
+    return createGroup;
   };
 
   //그룹 전체 조회
@@ -37,7 +36,6 @@ module.exports = class GroupRepository {
 
   //그룹 삭제시, 삭제할 groupId 있는지 찾아보기
   findGroupId = async ({ groupId }) => {
-    logger.info(`GroupRepository.findGroupId Request`);
     const findGroupData = await Groups.findOne({ where: { groupId } });
     return findGroupData;
   };

--- a/src/api/services/group.service.js
+++ b/src/api/services/group.service.js
@@ -1,23 +1,24 @@
 const { logger } = require('../../middlewares/logger');
 const { BadRequestError, NotFoundError } = require('../../exceptions/errors');
-const GroupRepository = require('../repositories/groups.repository');
+const GroupRepository = require('../repositories/group.repository');
 
 module.exports = class GroupService {
   constructor() {
     this.groupRepository = new GroupRepository();
   }
-  // 클라이언트 그룹 생성
+  // 빈 Group 생성
   createGroup = async ({
     //userId,
-    clientId,
     groupName,
     groupDescription,
   }) => {
+    logger.info(`GroupService.createGroup Request`);
     const groupData = await this.groupRepository.createGroup({
-      clientId,
+      // userId,
       groupName,
       groupDescription,
     });
+
     if (!groupData) {
       throw new BadRequestError('그룹 생성에 실패하였습니다.');
     }
@@ -33,8 +34,6 @@ module.exports = class GroupService {
   };
 
   //그룹 삭제
-  //그룹아이디 요청받아서 리포지 그룹아이디 불러봤는데
-  //없는 아이디라면 조회에 실패했다는 에러 메시지 반환
   deleteGroup = async ({ groupId }) => {
     logger.info(`GroupService.deleteGroup Request`);
     const findGroupData = await this.groupRepository.findGroupId({ groupId });


### PR DESCRIPTION
API 명세서에 응답시 groupId를 반환하는 걸 어떤식으로 작성해야될지 몰라 기본코드만 작성했습니다.

#201 그룹 생성에 성공 시

{ 
”groupId”: 2,
”message”: “그룹 생성이 완료되었습니다.” 
}