### PR TITLE
fix: 클라이언트 조회 및 그룹별 클라이언트 조회시 검색 기능수정

### DIFF
--- a/src/repositories/client.repository.js
+++ b/src/repositories/client.repository.js
@@ -27,7 +27,6 @@ module.exports = class ClientRepository {
     return createData;
   };
 
-  // 클라이언트 목록에서 검색
   findkeyword = async ({ userId, companyId, keyword, offset }) => {
     logger.info(`ClientRepository.findkeyword Request`);
 
@@ -51,11 +50,13 @@ module.exports = class ClientRepository {
       include: [
         {
           model: ClientGroups,
-          attributes: ['userId'],
+          attributes: [groupId],
+          where: { userId },
           include: [
             {
               model: Groups,
-              attributes: ['groupName'],
+              attributes: ['groupId', 'groupName'],
+              where: { groupName: { [Op.like]: `%${keyword}%` } },
             },
           ],
         },

--- a/src/services/client.service.js
+++ b/src/services/client.service.js
@@ -49,7 +49,7 @@ module.exports = class ClientService {
     }
     const offset = index ? parseInt(index - 1) : 0;
 
-    if (!groupId && keyword) {
+    if (keyword) {
       keyword = await this.clientRepository.findkeyword({
         userId,
         companyId,
@@ -74,17 +74,6 @@ module.exports = class ClientService {
       return { clients: allData, clientCount };
     }
 
-    // // 그룹별 클라이언트 검색
-    // if (groupId && keyword) {
-    //   keyword = await this.clientRepository.findkeywordBygroupId({
-    //     userId,
-    //     companyId,
-    //     groupId,
-    //     keyword,
-    //     offset,
-    //   });
-    //   return { keyword };
-    // }
     //그룹별 클라이언트 조회
     const existGroup = await this.groupRepository.findGroupId({
       userId,


### PR DESCRIPTION
검색 대상에 그룹명도 포함시키고 싶은데 계속 groupId를 인식 못한다고 에러가 나옵니다. 여러 시도를 해봐도 모르겠어서 일단 pr요청했습니다.